### PR TITLE
fix lightIndicatorLED prototype for ECv22 

### DIFF
--- a/v2/src/Extruder/boards/ecv22/ExtruderBoard.hh
+++ b/v2/src/Extruder/boards/ecv22/ExtruderBoard.hh
@@ -66,7 +66,7 @@ public:
 	/// Indicate an error by manipulating the debug LED.
 	void indicateError(int errorCode);
 
-        void flashIndicatorLED() {}
+        void lightIndicatorLED() {}
 
 	bool isUsingPlatform() { return using_platform; }
 	void setUsingPlatform(bool is_using);


### PR DESCRIPTION
Without this you'd get:

scons -f SConstruct.extruder platform=ecv22 port=/dev/cu.usbserial-FTF0GE9Y relays=false extstepper=true stepper=false upload

[..]

build_extruder/Host.cc: In function 'bool processQueryPacket(const InPacket&, OutPacket&)':
build_extruder/Host.cc:231: error: 'class ExtruderBoard' has no member named 'lightIndicatorLED'
scons: **\* [build_extruder/Host.o] Error 1

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
