### PR TITLE
3G 5D Shield 3.0

### DIFF
--- a/v2/src/Motherboard/EepromMap.hh
+++ b/v2/src/Motherboard/EepromMap.hh
@@ -32,6 +32,7 @@ const static uint16_t VERSION_HIGH				= 0x0001;
 
 /// Axis inversion flags: 1 byte.
 /// Axis N (where X=0, Y=1, etc.) is inverted if the Nth bit is set.
+/// Bit 7 is used for HoldZ OFF: 1 = off, 0 = on
 const static uint16_t AXIS_INVERSION			= 0x0002;
 
 /// Endstop inversion flags: 1 byte.

--- a/v2/src/Motherboard/boards/mb24/Motherboard.cc
+++ b/v2/src/Motherboard/boards/mb24/Motherboard.cc
@@ -99,7 +99,7 @@ void Motherboard::reset() {
 
 	// Init steppers
 	// NB: for now, we are turning on Z hold for these boards!
-	steppers::setHoldZ(true);
+    //steppers::setHoldZ(true);
 	for (int i = 0; i < STEPPER_COUNT; i++) {
 		stepper[i].init(i);
 	}

--- a/v2/src/Motherboard/boards/mb24/Motherboard.cc
+++ b/v2/src/Motherboard/boards/mb24/Motherboard.cc
@@ -26,6 +26,7 @@
 #include "Interface.hh"
 #include "Tool.hh"
 #include "Commands.hh"
+#include "Eeprom.hh"
 #include "EepromMap.hh"
 
 
@@ -98,8 +99,12 @@ void Motherboard::reset() {
 	indicateError(0); // turn off blinker
 
 	// Init steppers
-	// NB: for now, we are turning on Z hold for these boards!
-    //steppers::setHoldZ(true);
+	
+	uint8_t axis_invert = eeprom::getEeprom8(eeprom::AXIS_INVERSION, 0);
+	bool dont_hold_z = (axis_invert & (1<<7)) != 0;
+        if (dont_hold_z)
+                steppers::setHoldZ(true);
+
 	for (int i = 0; i < STEPPER_COUNT; i++) {
 		stepper[i].init(i);
 	}

--- a/v2/src/Motherboard/boards/rrmbv12/Configuration.hh
+++ b/v2/src/Motherboard/boards/rrmbv12/Configuration.hh
@@ -65,7 +65,7 @@
 // --- Axis configuration ---
 // Define the number of stepper axes supported by the board.  The axes are
 // denoted by X, Y, Z, A and B.
-#define STEPPER_COUNT           3
+#define STEPPER_COUNT           4
 
 // --- Stepper and endstop configuration ---
 // Pins should be defined for each axis present on the board.  They are denoted
@@ -76,6 +76,9 @@
 // if they are based on the H21LOI, they are not.
 #define DEFAULT_INVERTED_ENDSTOPS 1
 
+// If both ends of the endstops will trigger the same pin, set this to one
+#define SINGLE_SWITCH_ENDSTOPS 1
+
 // The X stepper step pin (active on rising edge)
 #define X_STEP_PIN              Pin(PortD,7)
 // The X direction pin (forward on logic high)
@@ -85,7 +88,7 @@
 // The X minimum endstop pin (active high)
 #define X_MIN_PIN               Pin(PortC,4)
 // The X maximum endstop pin (active high)
-#define X_MAX_PIN               Pin(PortC,5)
+#define X_MAX_PIN               Pin(PortC,4) // was 5
 
 // The Y stepper step pin (active on rising edge)
 #define Y_STEP_PIN              Pin(PortC,7)
@@ -96,7 +99,7 @@
 // The Y minimum endstop pin (active high)
 #define Y_MIN_PIN               Pin(PortA,6)
 // The Y maximum endstop pin (active high)
-#define Y_MAX_PIN               Pin(PortA,5)
+#define Y_MAX_PIN               Pin(PortA,6) // was 5
 
 // The Z stepper step pin (active on rising edge)
 #define Z_STEP_PIN              Pin(PortA,4)
@@ -107,7 +110,14 @@
 // The Z minimum endstop pin (active high)
 #define Z_MIN_PIN               Pin(PortA,1)
 // The Z maximum endstop pin (active high)
-#define Z_MAX_PIN               Pin(PortA,0)
+#define Z_MAX_PIN               Pin(PortA,1) // was 0
+
+// The A stepper step pin (active on rising edge)
+#define A_STEP_PIN              Pin(PortC,5)
+// The A direction pin (forward on logic high)
+#define A_DIR_PIN               Pin(PortA,5)
+// The A stepper enable pin (active low)
+#define A_ENABLE_PIN            Pin(PortA,0)
 
 // --- Debugging configuration ---
 // The pin which controls the debug LED (active high)

--- a/v2/src/Motherboard/boards/rrmbv12/Configuration.hh
+++ b/v2/src/Motherboard/boards/rrmbv12/Configuration.hh
@@ -76,8 +76,10 @@
 // if they are based on the H21LOI, they are not.
 #define DEFAULT_INVERTED_ENDSTOPS 1
 
+#ifdef FOURTH_STEPPER
 // If both ends of the endstops will trigger the same pin, set this to one
 #define SINGLE_SWITCH_ENDSTOPS 1
+#endif
 
 // The X stepper step pin (active on rising edge)
 #define X_STEP_PIN              Pin(PortD,7)
@@ -88,7 +90,11 @@
 // The X minimum endstop pin (active high)
 #define X_MIN_PIN               Pin(PortC,4)
 // The X maximum endstop pin (active high)
-#define X_MAX_PIN               Pin(PortC,4) // was 5
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+#define X_MAX_PIN               Pin(PortC,4)
+#else
+#define X_MAX_PIN               Pin(PortC,5)
+#endif
 
 // The Y stepper step pin (active on rising edge)
 #define Y_STEP_PIN              Pin(PortC,7)
@@ -99,7 +105,11 @@
 // The Y minimum endstop pin (active high)
 #define Y_MIN_PIN               Pin(PortA,6)
 // The Y maximum endstop pin (active high)
-#define Y_MAX_PIN               Pin(PortA,6) // was 5
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+#define Y_MAX_PIN               Pin(PortA,6)
+#else
+#define Y_MAX_PIN               Pin(PortA,5)
+#endif
 
 // The Z stepper step pin (active on rising edge)
 #define Z_STEP_PIN              Pin(PortA,4)
@@ -110,14 +120,21 @@
 // The Z minimum endstop pin (active high)
 #define Z_MIN_PIN               Pin(PortA,1)
 // The Z maximum endstop pin (active high)
-#define Z_MAX_PIN               Pin(PortA,1) // was 0
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+#define Z_MAX_PIN               Pin(PortA,1)
+#else
+#define Z_MAX_PIN               Pin(PortA,0)
+#endif
 
+#ifdef FOURTH_STEPPER
 // The A stepper step pin (active on rising edge)
 #define A_STEP_PIN              Pin(PortC,5)
 // The A direction pin (forward on logic high)
 #define A_DIR_PIN               Pin(PortA,5)
 // The A stepper enable pin (active low)
 #define A_ENABLE_PIN            Pin(PortA,0)
+#endif // FOURTH_STEPPER
+
 
 // --- Debugging configuration ---
 // The pin which controls the debug LED (active high)

--- a/v2/src/Motherboard/boards/rrmbv12/Motherboard.cc
+++ b/v2/src/Motherboard/boards/rrmbv12/Motherboard.cc
@@ -61,16 +61,16 @@ Motherboard::Motherboard(const Pin& psu_pin) :
         stepper[3] = StepperInterface(A_DIR_PIN,
                                       A_STEP_PIN,
                                       A_ENABLE_PIN,
-                                      A_MAX_PIN,
-                                      A_MIN_PIN,
+                                      Pin(),
+                                      Pin(),
                                       eeprom::AXIS_INVERSION);
 #endif
 #if STEPPER_COUNT > 4
         stepper[4] = StepperInterface(B_DIR_PIN,
                                       B_STEP_PIN,
                                       B_ENABLE_PIN,
-                                      B_MAX_PIN,
-                                      B_MIN_PIN,
+                                      Pin(),
+                                      Pin(),
                                       eeprom::AXIS_INVERSION);
 #endif
 }

--- a/v2/src/Motherboard/boards/rrmbv12/Motherboard.cc
+++ b/v2/src/Motherboard/boards/rrmbv12/Motherboard.cc
@@ -23,6 +23,7 @@
 #include "Configuration.hh"
 #include "Steppers.hh"
 #include "Command.hh"
+#include "Eeprom.hh"
 #include "EepromMap.hh"
 
 /// Instantiate static motherboard instance
@@ -86,6 +87,11 @@ void Motherboard::reset() {
         psu.turnOn(true);
 
 	// Init steppers
+	uint8_t axis_invert = eeprom::getEeprom8(eeprom::AXIS_INVERSION, 0);
+	bool dont_hold_z = (axis_invert & (1<<7)) != 0;
+        if (dont_hold_z)
+                steppers::setHoldZ(true);
+
 	for (int i = 0; i < STEPPER_COUNT; i++) {
 		stepper[i].init(i);
 	}

--- a/v2/src/SConscript.motherboard
+++ b/v2/src/SConscript.motherboard
@@ -39,6 +39,8 @@ import re
 from os.path import dirname
 # Parameters
 platform = ARGUMENTS.get('platform','mb24')
+# fived only applicable for rrmbv12
+fived = ARGUMENTS.get('fived','false')
 f_cpu='16000000L'
 
 
@@ -117,6 +119,9 @@ elif (os.environ.has_key('AVR32_HOME')):
 	avr_tools_path = os.environ['AVR32_HOME'] + '\\bin'
 else:
 	avr_tools_path = dirname(os.popen('/usr/bin/which avr-gcc').readlines()[0])
+
+if (fived == 'true'):
+	flags.append('-DFOURTH_STEPPER=1')
 
 env=Environment(tools=['g++', 'gcc'],
         CC=avr_tools_path+"/avr-g++",

--- a/v2/src/shared/StepperAxis.cc
+++ b/v2/src/shared/StepperAxis.cc
@@ -61,24 +61,35 @@ void StepperAxis::doInterrupt(const int32_t intervals) {
                 counter -= intervals;
                 bool hit_endstop = direction ? interface->isAtMaximum() : interface->isAtMinimum();
 #if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
-                if (hit_endstop) {
+                // We must move at least ENDSTOP_DEBOUNCE from where we hit the endstop before we declare traveling
+                if (hit_endstop || ((endstop_play < ENDSTOP_DEFAULT_PLAY - ENDSTOP_DEBOUNCE) && endstop_status != ESS_TRAVELING)) {
                 // Did we *just* hit the endstop?
-                        if (endstop_status == ESS_TRAVELING || endstop_status == ESS_UNKNOWN) {
-                                if (endstop_status != ESS_UNKNOWN)
-                                        endstop_status = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
-                                hit_endstop = false; // pretend this never happened... :-)
+                        if (endstop_status == ESS_TRAVELING) {
+                                endstop_play   = ENDSTOP_DEFAULT_PLAY;
+                                if (prev_direction)
+                                        endstop_status = ESS_AT_MAXIMUM;
+                                else
+                                        endstop_status = ESS_AT_MINIMUM;
 
                 // OR, are we traveling away from the endstop we just hit and still have play...
-                        } else if (endstop_play > 0 && (endstop_status != (direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM))) {
-                                --endstop_play;
-                                hit_endstop = false; // pretend this never happened... :-)
+                        } else if ((direction && endstop_status != ESS_AT_MAXIMUM) || (!direction && endstop_status != ESS_AT_MINIMUM)) {
+                                if (endstop_play > 0) {
+                                        --endstop_play;
+                                        hit_endstop = false; // pretend this never happened...
+                                } else {
+                                        // we ran out of play, so we must be ramming into the side, switch directions
+                                        // endstop_status = !direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
+                                        // endstop_play   = ENDSTOP_DEFAULT_PLAY;
+                                }
                         }
                 // otherwise we hit the endstop
 
                 // but if we didn't hit an endstop, clear the status
                 } else {
                         endstop_status = ESS_TRAVELING;
+                        endstop_play   = ENDSTOP_DEFAULT_PLAY;
                 }
+                prev_direction = direction;
 #endif //SINGLE_SWITCH_ENDSTOPS
                 if (direction) {
                         if (!hit_endstop) interface->step(true);
@@ -100,29 +111,35 @@ bool StepperAxis::doHoming(const int32_t intervals) {
                 counter -= intervals;
                 bool hit_endstop           = direction ? interface->isAtMaximum() : interface->isAtMinimum();
 #if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
-// For homing we act a little different .. we assume we are there if we start out hitting the endstop
-                if (hit_endstop) {
-                // Did we *just* hit the endstop?
-                        if (endstop_status == ESS_UNKNOWN) {
-                    // we "hit" the endstop, so we'll record this direction as the one we hit
-                                endstop_status     = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
-                        } else if (endstop_status == ESS_TRAVELING) {
-                                endstop_play       = ENDSTOP_DEFAULT_PLAY;
-                                if (endstop_status != ESS_UNKNOWN)
-                                        endstop_status = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
-                                hit_endstop        = false; // pretend this never happened... :-)
+                // For homing we act a little different .. we assume we are there if we start out hitting the endstop
+                if (hit_endstop|| ((endstop_play < ENDSTOP_DEFAULT_PLAY - ENDSTOP_DEBOUNCE) && endstop_status != ESS_TRAVELING)) {
+                        // Did we *just* hit the endstop?
+                        if (endstop_status == ESS_TRAVELING || endstop_status == ESS_UNKNOWN) {
+                        // we "hit" the endstop, so we'll record this direction as the one we hit
+                                endstop_play   = ENDSTOP_DEFAULT_PLAY;
+                                if (direction)
+                                        endstop_status = ESS_AT_MAXIMUM;
+                                else
+                                        endstop_status = ESS_AT_MINIMUM;
 
-                // OR, are we traveling away from the endstop we just hit and still have play...
-                        } else if (endstop_play > 0 && (endstop_status != (direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM))) {
-                                --endstop_play;
-                                hit_endstop        = false; // pretend this never happened... :-)
+                        // OR, are we traveling away from the endstop we just hit
+                        } else if ((direction && endstop_status != ESS_AT_MAXIMUM) || (!direction && endstop_status != ESS_AT_MINIMUM)) {
+                                if (endstop_play > 0) {
+                                        --endstop_play;
+                                        hit_endstop = false; // pretend this never happened... :-)
+                                } else {
+                                        // we ran out of play, so we must be ramming into the side, switch directions
+                                        // endstop_status = direction ? ESS_AT_MINIMUM : ESS_AT_MAXIMUM;
+                                        // endstop_play   = ENDSTOP_DEFAULT_PLAY;
+                                }
                         }
-                // otherwise we hit the endstop
+                        // otherwise we hit the endstop
 
                 // but if we didn't hit an endstop, clear the status
                 } else {
-                        endstop_status         = ESS_TRAVELING;
+                        endstop_status = ESS_TRAVELING;
                 }
+                prev_direction = direction;
 #endif //SINGLE_SWITCH_ENDSTOPS
 
                 if (direction) {

--- a/v2/src/shared/StepperAxis.cc
+++ b/v2/src/shared/StepperAxis.cc
@@ -48,8 +48,10 @@ void StepperAxis::reset() {
         target = 0;
         counter = 0;
         delta = 0;
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
         endstop_play = ENDSTOP_DEFAULT_PLAY;
         endstop_status = ESS_UNKNOWN;
+#endif //SINGLE_SWITCH_ENDSTOPS
 }
 
 void StepperAxis::doInterrupt(const int32_t intervals) {

--- a/v2/src/shared/StepperAxis.cc
+++ b/v2/src/shared/StepperAxis.cc
@@ -48,6 +48,8 @@ void StepperAxis::reset() {
         target = 0;
         counter = 0;
         delta = 0;
+        endstop_play = ENDSTOP_DEFAULT_PLAY;
+        endstop_status = ESS_UNKNOWN;
 }
 
 void StepperAxis::doInterrupt(const int32_t intervals) {
@@ -55,11 +57,32 @@ void StepperAxis::doInterrupt(const int32_t intervals) {
         if (counter >= 0) {
                 interface->setDirection(direction);
                 counter -= intervals;
+                bool hit_endstop = direction ? interface->isAtMaximum() : interface->isAtMinimum();
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+                if (hit_endstop) {
+                // Did we *just* hit the endstop?
+                        if (endstop_status == ESS_TRAVELING || endstop_status == ESS_UNKNOWN) {
+                                if (endstop_status != ESS_UNKNOWN)
+                                        endstop_status = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
+                                hit_endstop = false; // pretend this never happened... :-)
+
+                // OR, are we traveling away from the endstop we just hit and still have play...
+                        } else if (endstop_play > 0 && (endstop_status != (direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM))) {
+                                --endstop_play;
+                                hit_endstop = false; // pretend this never happened... :-)
+                        }
+                // otherwise we hit the endstop
+
+                // but if we didn't hit an endstop, clear the status
+                } else {
+                        endstop_status = ESS_TRAVELING;
+                }
+#endif //SINGLE_SWITCH_ENDSTOPS
                 if (direction) {
-                        if (!interface->isAtMaximum()) interface->step(true);
+                        if (!hit_endstop) interface->step(true);
                         position++;
                 } else {
-                        if (!interface->isAtMinimum()) interface->step(true);
+                        if (!hit_endstop) interface->step(true);
                         position--;
                 }
                 interface->step(false);
@@ -73,15 +96,42 @@ bool StepperAxis::doHoming(const int32_t intervals) {
         if (counter >= 0) {
                 interface->setDirection(direction);
                 counter -= intervals;
+                bool hit_endstop           = direction ? interface->isAtMaximum() : interface->isAtMinimum();
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+// For homing we act a little different .. we assume we are there if we start out hitting the endstop
+                if (hit_endstop) {
+                // Did we *just* hit the endstop?
+                        if (endstop_status == ESS_UNKNOWN) {
+                    // we "hit" the endstop, so we'll record this direction as the one we hit
+                                endstop_status     = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
+                        } else if (endstop_status == ESS_TRAVELING) {
+                                endstop_play       = ENDSTOP_DEFAULT_PLAY;
+                                if (endstop_status != ESS_UNKNOWN)
+                                        endstop_status = direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM;
+                                hit_endstop        = false; // pretend this never happened... :-)
+
+                // OR, are we traveling away from the endstop we just hit and still have play...
+                        } else if (endstop_play > 0 && (endstop_status != (direction ? ESS_AT_MAXIMUM : ESS_AT_MINIMUM))) {
+                                --endstop_play;
+                                hit_endstop        = false; // pretend this never happened... :-)
+                        }
+                // otherwise we hit the endstop
+
+                // but if we didn't hit an endstop, clear the status
+                } else {
+                        endstop_status         = ESS_TRAVELING;
+                }
+#endif //SINGLE_SWITCH_ENDSTOPS
+
                 if (direction) {
-                        if (!interface->isAtMaximum()) {
+                        if (!hit_endstop) {
                                 interface->step(true);
                         } else {
                                 return false;
                         }
                         position++;
                 } else {
-                        if (!interface->isAtMinimum()) {
+                        if (!hit_endstop) {
                                 interface->step(true);
                         } else {
                                 return false;

--- a/v2/src/shared/StepperAxis.hh
+++ b/v2/src/shared/StepperAxis.hh
@@ -2,6 +2,11 @@
 #define STEPPERAXIS_HH
 
 #include "StepperInterface.hh"
+#include "Configuration.hh"
+
+// If we started with an endstop triggered, then we don't know where we are
+// So we can go this many steps either way until we find out...
+#define ENDSTOP_DEFAULT_PLAY 10000
 
 /// The stepper axis module implmeents a driver for a single stepper axis. It is designed
 /// to be accessed via the Steppers namespace, and uses a StepperInterface to talk to the
@@ -20,6 +25,18 @@ public:
                                         ///< zero, a step is taken.
         volatile int32_t delta;         ///< Amount to increment counter per tick
         volatile bool direction;        ///< True for positive, false for negative
+#if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+        volatile int32_t endstop_play;  ///< Amount to move while endstop triggered, to see which way to move
+        
+        enum endstop_status_t {///< State of the endstop
+            ESS_UNKNOWN,
+            ESS_TRAVELING,
+            ESS_AT_MAXIMUM,
+            ESS_AT_MINIMUM
+        };
+        
+        volatile endstop_status_t endstop_status;
+#endif //SINGLE_SWITCH_ENDSTOPS
 
 public:
         /// Construct a stepper axis with a null interface

--- a/v2/src/shared/StepperAxis.hh
+++ b/v2/src/shared/StepperAxis.hh
@@ -6,7 +6,9 @@
 
 // If we started with an endstop triggered, then we don't know where we are
 // So we can go this many steps either way until we find out...
+// TODO: These should be in EEPROM, most likely, and per-axis
 #define ENDSTOP_DEFAULT_PLAY 10000
+#define ENDSTOP_DEBOUNCE 20
 
 /// The stepper axis module implmeents a driver for a single stepper axis. It is designed
 /// to be accessed via the Steppers namespace, and uses a StepperInterface to talk to the
@@ -26,9 +28,10 @@ public:
         volatile int32_t delta;         ///< Amount to increment counter per tick
         volatile bool direction;        ///< True for positive, false for negative
 #if defined(SINGLE_SWITCH_ENDSTOPS) && (SINGLE_SWITCH_ENDSTOPS == 1)
+        volatile bool prev_direction;   ///< Record the previous direction for endstop detection
         volatile int32_t endstop_play;  ///< Amount to move while endstop triggered, to see which way to move
         
-        enum endstop_status_t {///< State of the endstop
+        enum endstop_status_t {         ///< State of the endstop
             ESS_UNKNOWN,
             ESS_TRAVELING,
             ESS_AT_MAXIMUM,


### PR DESCRIPTION
This is, I assume, where the 3.0 code is living for now, so I'm doing a pull request to here. Let me know if this is wrong. :)

This is primarily to support the changes to the Gen3 MB (rrmbv12) to work with http://www.thingiverse.com/thing:11837 where both endstops for an axis are on the same pin. This requires some extra logic when and endstop is hit, since it doesn't actually know what end got hit.

I added a flag to scons (fived=true) that will only apply to the rrmbv12.

I also added to both motherboard an EEPROM setting for HoldZ. It defaults to ON -- and lives in bit 7 of the axis inversion byte. I thought that bit would neve be used, but I could be wrong. I'll do a pull request to add this to RepG next...
