### PR TITLE
ECv22 can run a fan off the second h-bridge.

### DIFF
--- a/v2/src/Extruder/boards/ecv22/Configuration.hh
+++ b/v2/src/Extruder/boards/ecv22/Configuration.hh
@@ -64,10 +64,6 @@
 #define CHANNEL_B               Pin(PortB,3)
 #define CHANNEL_C               Pin(PortB,4)
 
-// Fan configuration
-#define HAS_FAN                 1
-#define FAN_ENABLE_PIN          CHANNEL_C
-
 #define HB1_ENABLE_PIN          Pin(PortD,5)
 #define HB1_DIR_PIN             Pin(PortD,7)
 

--- a/v2/src/Extruder/boards/ecv22/ExtruderBoard.cc
+++ b/v2/src/Extruder/boards/ecv22/ExtruderBoard.cc
@@ -272,8 +272,8 @@ void setChannel(ChannelChoice c, uint8_t value, bool binary) {
 }
 
 void ExtruderBoard::setFanRunning(bool state)
-{ // The Goggles, they do nothing!
-	// on these board, there is no toggle fan. This is vestigle
+{
+        setFanMotor(state);
 }
 
 void ExtruderBoard::setAutomatedBuildPlatformRunning(bool state) {

--- a/v2/src/Extruder/boards/ecv22/ExtruderMotor.hh
+++ b/v2/src/Extruder/boards/ecv22/ExtruderMotor.hh
@@ -26,8 +26,14 @@ void initExtruderMotor();
 
 /// Turn the extruder motor on
 /// \param[in] speed Set the motor speed, -255 to 255, where 0 means stop.
+/// \param[in] motor1 true to control motor 1, false to control motor 2 (fan)
 /// \ingroup ECv22
-void setExtruderMotor(int16_t speed);
+void setExtruderMotor(int16_t speed, bool motor1 = true);
+
+/// Turn the extruder fan on (calls setExtruderMotor with motor1 = false)
+/// \param[in] on true to turn the fan on, false to turn it off
+/// \ingroup ECv22
+void setFanMotor(bool on);
 
 /// For extruders with stepper motors: Set the stepper mode.
 /// \param[in] mode true to enable stepper, or false to disable.


### PR DESCRIPTION
I remapped the fan commands to the second (unused) h-bridge, instead of just saying "it can't be done." :-)

This also honors the "swap motor controllers" EEPRM flag.

Note: Electrically, I feel that the ABP motor should really be drive by the h-bridge, and the fan should be on the Channel C mosfet, but to avoid additional confusion when compared to the Gen4 setup, the way this code does it is probably best.
