### PR TITLE
Add Cutoff Support / Gen4 Interface enhancements

### DIFF
--- a/firmware/src/Motherboard/EepromMap.hh
+++ b/firmware/src/Motherboard/EepromMap.hh
@@ -49,6 +49,14 @@ const static uint16_t MACHINE_NAME				= 0x0020;
 /// Default locations for the axis: 5 x 32 bit = 20 bytes
 const static uint16_t AXIS_HOME_POSITIONS		= 0x0060;
 
+// Estop configuration byte: 1 byte.
+const static uint16_t ESTOP_CONFIGURATION = 0x0074;
+
+enum {
+	ESTOP_CONF_NONE = 0x0,
+	ESTOP_CONF_ACTIVE_HIGH = 0x1,
+	ESTOP_CONF_ACTIVE_LOW = 0x2
+};
 
 /// Reset all data in the EEPROM to a default.
 void setDefaults();

--- a/firmware/src/Motherboard/Errors.hh
+++ b/firmware/src/Motherboard/Errors.hh
@@ -29,7 +29,7 @@
 #define ERR_HOST_PACKET_TIMEOUT         4
 #define ERR_HOST_PACKET_MISC            5
 #define ERR_WDT_TIMEOUT                 6
-
+#define ERR_ESTOP			7
 #define ERR_HOST_TRUNCATED_CMD          8
 
 #endif /* ERRORS_HH_ */

--- a/firmware/src/Motherboard/Main.cc
+++ b/firmware/src/Motherboard/Main.cc
@@ -28,6 +28,7 @@
 #include "SDCard.hh"
 #include "Eeprom.hh"
 #include "EepromMap.hh"
+#include "Errors.hh"
 
 void reset(bool hard_reset) {
 	ATOMIC_BLOCK(ATOMIC_FORCEON) {
@@ -37,6 +38,16 @@ void reset(bool hard_reset) {
 		command::reset();
 		eeprom::init();
 		board.reset();
+#if HAS_ESTOP
+	const uint8_t estop_conf = eeprom::getEeprom8(eeprom::ESTOP_CONFIGURATION, 0);
+	if (estop_conf == eeprom::ESTOP_CONF_ACTIVE_HIGH) {
+		ESTOP_ENABLE_RISING_INT;
+	} else if (estop_conf == eeprom::ESTOP_CONF_ACTIVE_LOW) {
+		ESTOP_ENABLE_FALLING_INT;
+	}
+#endif
+
+		
 		sei();
 		// If we've just come from a hard reset, wait for 2.5 seconds before
 		// trying to ping an extruder.  This gives the extruder time to boot
@@ -72,3 +83,16 @@ int main() {
 	}
 	return 0;
 }
+
+ISR(ESTOP_vect, ISR_NOBLOCK) {
+	// Emergency stop triggered; reset everything and kill the interface to RepG
+	INTERFACE_BAR_PIN.setValue(true);
+	INTERFACE_BAR_PIN.setDirection(true);
+	tool::reset();
+	steppers::abort();
+	command::reset();
+	UART::getHostUART().enable(false);
+	Motherboard::getBoard().indicateError(ERR_ESTOP);
+	
+}
+

--- a/firmware/src/Motherboard/boards/mb24/Configuration.hh
+++ b/firmware/src/Motherboard/boards/mb24/Configuration.hh
@@ -73,6 +73,10 @@
 #define HAS_ESTOP               1
 // The pin connected to the emergency stop
 #define ESTOP_PIN               Pin(PortE,4)
+// Macros for enabling interrupts on the the pin. In this case, INT4.
+#define ESTOP_ENABLE_RISING_INT { EICRB = 0x03; EIMSK |= 0x10; }
+#define ESTOP_ENABLE_FALLING_INT { EICRB = 0x02; EIMSK |= 0x10; }
+#define ESTOP_vect INT4_vect
 
 
 // --- Axis configuration ---

--- a/firmware/src/Motherboard/boards/mb24/Motherboard.cc
+++ b/firmware/src/Motherboard/boards/mb24/Motherboard.cc
@@ -132,6 +132,12 @@ void Motherboard::reset() {
 	// Configure the debug pin.
 	DEBUG_PIN.setDirection(true);
 
+#if HAS_ESTOP
+	// Configure the estop pin direction.
+	ESTOP_PIN.setDirection(false);
+#endif
+
+
 	// Check if the interface board is attached
         hasInterfaceBoard = interface::isConnected();
 

--- a/firmware/src/shared/LiquidCrystal.cc
+++ b/firmware/src/shared/LiquidCrystal.cc
@@ -260,6 +260,30 @@ inline void LiquidCrystal::write(uint8_t value) {
 }
 
 
+void LiquidCrystal::writeZheight(uint32_t value) {
+
+	uint32_t currentDigit = 100000;
+	uint32_t nextDigit;
+
+		nextDigit = currentDigit/10;
+		write((value%currentDigit)/nextDigit+'0');
+		currentDigit = nextDigit;
+		nextDigit = currentDigit/10;
+		write((value%currentDigit)/nextDigit+'0');
+		currentDigit = nextDigit;
+		nextDigit = currentDigit/10;
+		write((value%currentDigit)/nextDigit+'0');
+		currentDigit = nextDigit;
+		write('.');
+		nextDigit = currentDigit/10;
+		write((value%currentDigit)/nextDigit+'0');
+		currentDigit = nextDigit;
+		nextDigit = currentDigit/10;
+		write((value%currentDigit)/nextDigit+'0');
+}
+
+
+
 void LiquidCrystal::writeInt(uint16_t value, uint8_t digits) {
 
 	uint16_t currentDigit;

--- a/firmware/src/shared/LiquidCrystal.hh
+++ b/firmware/src/shared/LiquidCrystal.hh
@@ -85,6 +85,8 @@ public:
   virtual void write(uint8_t);
 
   /** Added by MakerBot Industries to support storing strings in flash **/
+  void writeZheight(uint32_t value);
+
   void writeInt(uint16_t value, uint8_t digits);
 
   void writeString(char message[]);

--- a/firmware/src/shared/Menu.hh
+++ b/firmware/src/shared/Menu.hh
@@ -94,6 +94,7 @@ class JogMode: public Screen {
 private:
 	enum distance_t {
 	  DISTANCE_SHORT,
+	  DISTANCE_MED,
 	  DISTANCE_LONG,
 	};
 
@@ -111,6 +112,34 @@ public:
 
         void notifyButtonPressed(ButtonArray::ButtonName button);
 };
+
+class ExtruderMode: public Screen {
+private:
+	enum time_t {
+	  TIME_10S,
+	  TIME_30S,
+	  TIME_60S,
+	};
+
+	time_t extrudeTime;
+	bool timeChanged;
+
+	uint8_t updatePhase;
+
+	void changeTemp(ButtonArray::ButtonName direction);
+
+        void extrude(ButtonArray::ButtonName direction);
+
+public:
+	micros_t getUpdateRate() {return 50L * 1000L;}
+
+	void update(LiquidCrystal& lcd, bool forceRedraw);
+
+	void reset();
+
+        void notifyButtonPressed(ButtonArray::ButtonName button);
+};
+
 
 /// This is an easter egg.
 class SnakeMode: public Screen {
@@ -204,6 +233,7 @@ public:
 };
 
 
+
 class MainMenu: public Menu {
 public:
 	MainMenu();
@@ -218,6 +248,7 @@ private:
         MonitorMode monitorMode;
         SDMenu sdMenu;
         JogMode jogger;
+	    ExtruderMode extruder;
         SnakeMode snake;
 };
 


### PR DESCRIPTION
There are two unrelated commits here.
97db22a adds Cutoff (ESTOP) support for the Gen 4 motherboard.

881d776 adds some enhancements to the Interface board menus

I've written two mods for my TOM w/Gen4 electronics and an MK6+ extruder. Both are related to the Gen4 Interface board, and were intended to allow complete untethered operation of the 'bot. I started this without being aware of some similar efforts, but since it is done and tested I decided to post the changes.
1. Show the current Z position on the Monitor menu. The second line wasn't used for anything, and it was the easiest way I could think of to add some kind of build progress indicator when building from an SD card. The Z height is shown to the closest 0.01mm. I had to cheat a little here, as the bot doesn't actually know mm, just steps, so I hard coded it for 200 steps/mm.
2. Added an Extruder controller menu, modeled on the Jog menu. This one allows the Extruder temperature to be set from the control panel. Without this I needed to use the RepG control panel to change filament. X+ and X- change the set point by +/- 10C, Y+ and Y- change it by 1C. Zero sets it to 0C. Z+ and Z- run the Extruder forwards and backwards. The OK button selects either 10s, 30s, or 60s extruder run time. 
3. Modified the Jog menu to add a 2000 step jog distance in addition to the 20 and 200 step options.
